### PR TITLE
Preserve function metadata and support **kwargs in contracts()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+.venv
+build
+pystitia.egg-info

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ def withdraw(balance, amount):
     return balance - amount
 ```
 
+### Keyword Arguments
+
+Decorated functions can be called with positional arguments, keyword arguments, or a mix of both, just like the original undecorated function:
+
+```python
+@contracts(
+    preconditions=[
+        lambda balance, amount: amount > 0,
+        lambda balance, amount: balance >= amount
+    ]
+)
+def withdraw(balance, amount):
+    return balance - amount
+
+withdraw(100, 30)              # positional
+withdraw(balance=100, amount=30)  # keyword
+withdraw(100, amount=30)       # mixed
+```
+
 ### Checking Object Mutations
 
 Pystitia allows you to verify whether objects were modified during function execution:
@@ -234,7 +253,6 @@ except PostConditionError as e:
 
 - Requires explicit `setTestMode()` call before use
 - Deep copying adds overhead for postconditions using `__old__`
-- Decorated functions lose their original signature (affects IDE autocomplete)
 - No support for class invariants (yet)
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pystitia"
-version = "1.4"
+version = "1.5.0"
 authors = [
   { name="Ashwin Panchapakesan", email="ashwin.panchapakesan@gmail.com" },
 ]
@@ -21,3 +21,7 @@ license-files = ["LICEN[CS]E*"]
 [project.urls]
 Homepage = "https://github.com/inspectorG4dget/pystitia"
 Issues = "https://github.com/inspectorG4dget/pystitia/issues"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/pystitia.py
+++ b/pystitia.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import inspect
 
 from argparse import Namespace
@@ -6,7 +7,8 @@ from argparse import Namespace
 
 def contracts(preconditions=(), postconditions=()):
     def decorator(fn):
-        def wrapper(*args):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
             try: __testmode__
             except: raise NameError("__testmode__ not set")
 
@@ -14,15 +16,15 @@ def contracts(preconditions=(), postconditions=()):
             if __testmode__:
                 fails = []
                 for i,func in enumerate(preconditions):
-                    if not callCondition(fn, func, args): fails.append(i)
+                    if not callCondition(fn, func, args, kwargs): fails.append(i)
                 if fails:
                     raise PreConditionError(f"PreCondition functions failed on {fn.__name__} in {inspect.getabsfile(fn)}:{inspect.getsourcelines(fn)[1]}:\n\t {','.join(map(str, fails))}")
 
-            if postconditions: __old__, __id__ = cacheOld(fn, args)
+            if postconditions: __old__, __id__ = cacheOld(fn, args, kwargs)
 
             fn.__globals__['__testmode__'] = __testmode__
             try:
-                __return__ = fn(*args)
+                __return__ = fn(*args, **kwargs)
             except Exception as e:
                 print("DEBUG:", fn)
                 # fn(*args)
@@ -30,12 +32,13 @@ def contracts(preconditions=(), postconditions=()):
 
             if __testmode__:
                 fails = []
+                extra = {'__return__': __return__, '__old__': __old__, '__id__': __id__} if postconditions else None
                 for i,func in enumerate(postconditions):
                     func.__globals__['__old__'] = __old__
                     func.__globals__['__id__'] = __id__
                     func.__globals__['__return__'] = __return__
 
-                    if not callCondition(fn, func, args): fails.append(i)
+                    if not callCondition(fn, func, args, kwargs, extra): fails.append(i)
                 if fails: raise PostConditionError("PostCondition functions failed on {} in {}:{}:\n\t {}".format(fn.__name__, inspect.getabsfile(fn), inspect.getsourcelines(fn)[1], ' '.join(map(str, fails))))
 
             return __return__
@@ -43,16 +46,22 @@ def contracts(preconditions=(), postconditions=()):
     return decorator
 
 
-def callCondition(fn, func, args):
-    callArgs = inspect.getcallargs(fn, *args)
+def callCondition(fn, func, args, kwargs, extra=None):
+    bound = inspect.signature(fn).bind(*args, **kwargs)
+    bound.apply_defaults()
+    callArgs = dict(bound.arguments)
+    if extra:
+        callArgs.update(extra)
     needArgs = set(inspect.getfullargspec(func).args)
     return func(**{k:v for k,v in callArgs.items() if k in needArgs})
 
 
-def cacheOld(fn, args):
+def cacheOld(fn, args, kwargs):
     __old__ = Namespace()
     __id__ = Namespace()
-    for k,v in inspect.getcallargs(fn, *args).items():
+    bound = inspect.signature(fn).bind(*args, **kwargs)
+    bound.apply_defaults()
+    for k,v in bound.arguments.items():
         __old__.__setattr__(k, copy.deepcopy(v))
         __id__.__setattr__(k, id(v))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 build==1.3.0
 twine==6.2.0
+pytest==9.1.1

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,263 @@
+import inspect
+
+import pytest
+
+from pystitia import (
+    PostConditionError,
+    PreConditionError,
+    contracts,
+    setTestMode,
+)
+
+
+@pytest.fixture(autouse=True)
+def test_mode():
+    setTestMode(True)
+    yield
+    setTestMode(True)
+
+
+# ---------------------------------------------------------------------------
+# functools.wraps metadata preservation
+# ---------------------------------------------------------------------------
+
+def test_preserves_name():
+    @contracts()
+    def square_root(x):
+        """Compute the square root of x."""
+        return x ** 0.5
+
+    assert square_root.__name__ == "square_root"
+
+
+def test_preserves_docstring():
+    @contracts()
+    def square_root(x):
+        """Compute the square root of x."""
+        return x ** 0.5
+
+    assert square_root.__doc__ == "Compute the square root of x."
+
+
+def test_preserves_module():
+    @contracts()
+    def square_root(x):
+        return x ** 0.5
+
+    assert square_root.__module__ == __name__
+
+
+def test_preserves_qualname():
+    class Foo:
+        @contracts()
+        def bar(self):
+            return 1
+
+    assert Foo.bar.__qualname__.endswith("Foo.bar")
+
+
+def test_exposes_wrapped():
+    def square_root(x):
+        return x ** 0.5
+
+    decorated = contracts()(square_root)
+    assert decorated.__wrapped__ is square_root
+
+
+def test_signature_matches_original():
+    @contracts()
+    def square_root(x, y=2):
+        return x ** (1 / y)
+
+    sig = inspect.signature(square_root)
+    assert list(sig.parameters) == ["x", "y"]
+    assert sig.parameters["y"].default == 2
+
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+
+def test_precondition_pass():
+    @contracts(preconditions=[lambda x: x > 0])
+    def square_root(x):
+        return x ** 0.5
+
+    assert square_root(16) == 4.0
+
+
+def test_precondition_fail_raises():
+    @contracts(preconditions=[lambda x: x > 0])
+    def square_root(x):
+        return x ** 0.5
+
+    with pytest.raises(PreConditionError):
+        square_root(-5)
+
+
+def test_multiple_stacked_preconditions_all_checked():
+    calls = []
+
+    def cond_a(x):
+        calls.append("a")
+        return x > 0
+
+    def cond_b(x):
+        calls.append("b")
+        return x < 100
+
+    @contracts(preconditions=[cond_a, cond_b])
+    def identity(x):
+        return x
+
+    assert identity(5) == 5
+    assert calls == ["a", "b"]
+
+
+def test_precondition_failure_reports_failed_index():
+    @contracts(preconditions=[lambda x: x > 0, lambda x: x < 10])
+    def identity(x):
+        return x
+
+    with pytest.raises(PreConditionError) as excinfo:
+        identity(20)
+    assert "identity" in str(excinfo.value)
+    assert "1" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Postconditions
+# ---------------------------------------------------------------------------
+
+def test_postcondition_pass():
+    @contracts(postconditions=[lambda __return__: __return__ > 0])
+    def square_root(x):
+        return x ** 0.5
+
+    assert square_root(16) == 4.0
+
+
+def test_postcondition_fail_raises():
+    @contracts(postconditions=[lambda __return__: __return__ > 100])
+    def square_root(x):
+        return x ** 0.5
+
+    with pytest.raises(PostConditionError):
+        square_root(16)
+
+
+def test_multiple_stacked_postconditions_all_checked():
+    calls = []
+
+    def cond_a(__return__):
+        calls.append("a")
+        return __return__ > 0
+
+    def cond_b(__return__):
+        calls.append("b")
+        return __return__ < 100
+
+    @contracts(postconditions=[cond_a, cond_b])
+    def identity(x):
+        return x
+
+    assert identity(5) == 5
+    assert calls == ["a", "b"]
+
+
+def test_postcondition_failure_reports_failed_index():
+    @contracts(postconditions=[lambda __return__: __return__ > 0, lambda __return__: __return__ < 10])
+    def identity(x):
+        return x
+
+    with pytest.raises(PostConditionError) as excinfo:
+        identity(20)
+    assert "identity" in str(excinfo.value)
+    assert "1" in str(excinfo.value)
+
+
+def test_postcondition_old_value_access():
+    @contracts(postconditions=[lambda __return__, amount: __return__ == __old__.balance - amount])
+    def withdraw(balance, amount):
+        return balance - amount
+
+    assert withdraw(100, 30) == 70
+
+
+def test_postcondition_id_immutability_check():
+    @contracts(postconditions=[lambda data: id(data) == __id__.data])
+    def append_item(data, item):
+        data.append(item)
+        return data
+
+    assert append_item([1, 2], 3) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# setTestMode
+# ---------------------------------------------------------------------------
+
+def test_setTestMode_false_bypasses_precondition_checks():
+    @contracts(preconditions=[lambda x: x > 0])
+    def identity(x):
+        return x
+
+    setTestMode(False)
+    try:
+        assert identity(-5) == -5
+    finally:
+        setTestMode(True)
+
+
+# ---------------------------------------------------------------------------
+# Keyword-argument support
+# ---------------------------------------------------------------------------
+
+def test_call_with_positional_args():
+    @contracts(preconditions=[lambda balance, amount: amount > 0])
+    def withdraw(balance, amount):
+        return balance - amount
+
+    assert withdraw(100, 30) == 70
+
+
+def test_call_with_keyword_args():
+    @contracts(preconditions=[lambda balance, amount: amount > 0])
+    def withdraw(balance, amount):
+        return balance - amount
+
+    assert withdraw(balance=100, amount=30) == 70
+
+
+def test_call_with_mixed_args():
+    @contracts(preconditions=[lambda balance, amount: amount > 0])
+    def withdraw(balance, amount):
+        return balance - amount
+
+    assert withdraw(100, amount=30) == 70
+
+
+def test_call_with_keyword_args_uses_default_value():
+    @contracts(preconditions=[lambda x, y: y > 0])
+    def power(x, y=2):
+        return x ** y
+
+    assert power(x=3) == 9
+    assert power(x=3, y=3) == 27
+
+
+def test_postcondition_old_value_with_keyword_call():
+    @contracts(postconditions=[lambda __return__, amount: __return__ == __old__.balance - amount])
+    def withdraw(balance, amount):
+        return balance - amount
+
+    assert withdraw(balance=100, amount=30) == 70
+
+
+def test_precondition_failure_with_keyword_call():
+    @contracts(preconditions=[lambda amount: amount > 0])
+    def withdraw(balance, amount):
+        return balance - amount
+
+    with pytest.raises(PreConditionError):
+        withdraw(balance=100, amount=-30)


### PR DESCRIPTION
The wrapper produced by @contracts() dropped the decorated function's __name__/__doc__/__module__/signature and only accepted positional args, breaking tracebacks, introspection, and any keyword-argument call site (GH #6). Apply functools.wraps and thread **kwargs through wrapper/callCondition/cacheOld, migrating off the deprecated inspect.getcallargs to Signature.bind in the process.

While adding postcondition tests, found that __return__/__old__/__id__ declared as explicit postcondition parameters (as the README shows) never actually got bound, since callCondition only pulled from fn's own arguments. Fixed by merging those special values into the candidate pool for postcondition parameter binding.


Claude-Session: https://claude.ai/code/session_01EtN9wgbkDjZYsAZB6UNUB1